### PR TITLE
Autocomplete query fixed

### DIFF
--- a/lib/src/autocomplete/autocomplete_parameters.dart
+++ b/lib/src/autocomplete/autocomplete_parameters.dart
@@ -38,14 +38,14 @@ class AutocompleteParameters {
 
     if (origin != null) {
       var item = {
-        'origin': '${origin.latitude},${origin.latitude}',
+        'origin': '${origin.latitude},${origin.longitude}',
       };
       queryParameters.addAll(item);
     }
 
     if (location != null) {
       var item = {
-        'location': '${location.latitude},${location.latitude}',
+        'location': '${location.latitude},${location.longitude}',
       };
       queryParameters.addAll(item);
     }
@@ -87,7 +87,7 @@ class AutocompleteParameters {
 
     if (strictbounds) {
       var item = {
-        'strictbounds': 'strictbounds',
+        'strictbounds': strictbounds.toString(),
       };
       queryParameters.addAll(item);
     }

--- a/lib/src/query_autocomplete/query_autocomplete.dart
+++ b/lib/src/query_autocomplete/query_autocomplete.dart
@@ -49,7 +49,7 @@ class QueryAutocomplete {
       radius,
       language,
     );
-    var uri = Uri.https(_authority, _unencodedPath, queryParameters);
+    var uri = Uri.parse(Uri.https(_authority, _unencodedPath, queryParameters).toString().replaceAll("%", ",").replaceAll(",2C", ","));
     var response = await NetworkUtility.fetchUrl(uri);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);

--- a/lib/src/query_autocomplete/query_autocomplete.dart
+++ b/lib/src/query_autocomplete/query_autocomplete.dart
@@ -49,7 +49,7 @@ class QueryAutocomplete {
       radius,
       language,
     );
-    var uri = Uri.parse(Uri.https(_authority, _unencodedPath, queryParameters).toString().replaceAll("%", ",").replaceAll(",2C", ","));
+    var uri = Uri.https(_authority, _unencodedPath, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);


### PR DESCRIPTION
Fixed the autocomplete parameters (location, origin and strictbounds) and the query autocomplete uri.

The issues found and fixed are listed below:

- The _strictbounds_ parameter used to be set to 'strictbounds' instead of setting it to the strictbounds parameter value
![image](https://user-images.githubusercontent.com/42593041/86088387-7d017e80-ba63-11ea-8dfe-347d4668828f.png)

- The _location_ and _origin_ parameters used to set the provided latitude in both the latitude and longitude instead of using its corresponding value
![image](https://user-images.githubusercontent.com/42593041/86088505-bc2fcf80-ba63-11ea-81a6-559ef51cb27e.png)

- The uri generated in line 52 of **query_automplete.dart** fileused to have **_'%'_** instead of **_','_** dividing the latitude and longitude, and also resulted in having a **_"2C"_** right before the longitud value
![image](https://user-images.githubusercontent.com/42593041/86088637-f5683f80-ba63-11ea-90d7-7a7fb0a45c34.png)
![image](https://user-images.githubusercontent.com/42593041/86089509-9a374c80-ba65-11ea-9514-6c6a7887f753.png)


Thanks for your work in this library, it has been very useful!!