### PR TITLE
Fix get() method documentation

### DIFF
--- a/lib/src/details/details.dart
+++ b/lib/src/details/details.dart
@@ -31,7 +31,7 @@ class Details {
   /// billing purposes. Use this for Place Details requests that are called following an autocomplete
   /// request in the same user session.
   ///
-  /// [sessionToken] Optional parameters - One or more fields, specifying the types of place data to return,
+  /// [fields] Optional parameters - One or more fields, specifying the types of place data to return,
   /// separated by a comma.
   Future<DetailsResponse?> get(
     String placeId, {


### PR DESCRIPTION
Documentation is related to `fields` parameter but wrongly refers to `sessionToken`