### PR TITLE
Allow passing custom headers for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [0.3.4] - 2021-07-01
+- Added ability to pass custom headers in requests.
+
 ## [0.3.3] - 2020-08-23
 
 - Add some commands

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -169,7 +169,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/google_place.dart
+++ b/lib/google_place.dart
@@ -64,11 +64,17 @@ class GooglePlace {
   /// [timeout] timeout for http call.
   static Duration timeout = Duration(milliseconds: 1500);
 
-  GooglePlace(this.apiKEY) {
-    this.search = Search(apiKEY);
-    this.details = Details(apiKEY);
-    this.photos = Photos(apiKEY);
-    this.autocomplete = Autocomplete(apiKEY);
-    this.queryAutocomplete = QueryAutocomplete(apiKEY);
+  /// Optional headers to pass on each request
+  final Map<String, String> headers;
+
+  GooglePlace(
+    this.apiKEY, {
+    this.headers = const {},
+  }) {
+    this.search = Search(apiKEY, headers);
+    this.details = Details(apiKEY, headers);
+    this.photos = Photos(apiKEY, headers);
+    this.autocomplete = Autocomplete(apiKEY, headers);
+    this.queryAutocomplete = QueryAutocomplete(apiKEY, headers);
   }
 }

--- a/lib/src/autocomplete/autocomplete.dart
+++ b/lib/src/autocomplete/autocomplete.dart
@@ -1,3 +1,4 @@
+import 'package:google_place/google_place.dart';
 import 'package:google_place/src/autocomplete/autocomplete_response.dart';
 import 'package:google_place/src/models/component.dart';
 import 'package:google_place/src/models/lat_lon.dart';
@@ -7,8 +8,9 @@ class Autocomplete {
   static final _authority = 'maps.googleapis.com';
   static final _unencodedPath = 'maps/api/place/autocomplete/json';
   final String apiKEY;
+  final Map<String, String> headers;
 
-  Autocomplete(this.apiKEY);
+  Autocomplete(this.apiKEY, this.headers);
 
   /// The Place Autocomplete service is a web service that returns place predictions in response
   ///  to an HTTP request. The request specifies a textual search string and optional geographic
@@ -91,7 +93,7 @@ class Autocomplete {
       strictbounds,
     );
     var uri = Uri.https(_authority, _unencodedPath, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);
     }

--- a/lib/src/details/details.dart
+++ b/lib/src/details/details.dart
@@ -1,3 +1,4 @@
+import 'package:google_place/google_place.dart';
 import 'package:google_place/src/details/details_response.dart';
 import 'package:google_place/src/utils/network_utility.dart';
 
@@ -5,8 +6,9 @@ class Details {
   static final _authority = 'maps.googleapis.com';
   static final _unencodedPath = 'maps/api/place/details/json';
   final String apiKEY;
+  final Map<String, String> headers;
 
-  Details(this.apiKEY);
+  Details(this.apiKEY, this.headers);
 
   /// Once you have a place_id from a Place Search, you can request more details about a
   /// particular establishment or point of interest by initiating a Place Details request.
@@ -51,7 +53,7 @@ class Details {
     );
 
     var uri = Uri.https(_authority, _unencodedPath, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return DetailsResponse.parseDetailsResult(response);
     }

--- a/lib/src/photos/photos.dart
+++ b/lib/src/photos/photos.dart
@@ -6,8 +6,9 @@ class Photos {
   static final _authority = 'maps.googleapis.com';
   static final _unencodedPath = 'maps/api/place/photo';
   final String apiKEY;
+  final Map<String, String> headers;
 
-  Photos(this.apiKEY);
+  Photos(this.apiKEY, this.headers);
 
   /// The Place Photo service, part of the Places API, is a read- only API that allows you to
   /// add high quality photographic content to your application. The Place Photo service gives
@@ -39,7 +40,7 @@ class Photos {
       maxWidth,
     );
     var uri = Uri.https(_authority, _unencodedPath, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       List<int> list = response.codeUnits;
       return Uint8List.fromList(list);
@@ -58,8 +59,7 @@ class Photos {
       'photoreference': photoReference,
       'key': apiKEY,
     };
-    if (maxHeight != null) {
-    }
+    if (maxHeight != null) {}
     if (maxWidth != null) {
       var item = {
         'maxwidth': maxWidth.toString(),

--- a/lib/src/query_autocomplete/query_autocomplete.dart
+++ b/lib/src/query_autocomplete/query_autocomplete.dart
@@ -1,3 +1,4 @@
+import 'package:google_place/google_place.dart';
 import 'package:google_place/src/autocomplete/autocomplete_response.dart';
 import 'package:google_place/src/models/lat_lon.dart';
 import 'package:google_place/src/utils/network_utility.dart';
@@ -6,8 +7,9 @@ class QueryAutocomplete {
   static final _authority = 'maps.googleapis.com';
   static final _unencodedPath = 'maps/api/place/queryautocomplete/json';
   final String apiKEY;
+  final Map<String, String> headers;
 
-  QueryAutocomplete(this.apiKEY);
+  QueryAutocomplete(this.apiKEY, this.headers);
 
   /// The Query Autocomplete service can be used to provide a query prediction for text-based
   /// geographic searches, by returning suggested queries as you type.
@@ -48,7 +50,7 @@ class QueryAutocomplete {
       language,
     );
     var uri = Uri.https(_authority, _unencodedPath, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);
     }

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -1,3 +1,4 @@
+import 'package:google_place/google_place.dart';
 import 'package:google_place/src/models/input_type.dart';
 import 'package:google_place/src/models/location.dart';
 import 'package:google_place/src/models/locationbias.dart';
@@ -14,8 +15,9 @@ class Search {
   static final _unencodedPathNearBySearch = 'maps/api/place/nearbysearch/json';
   static final _unencodedPathTextSearch = 'maps/api/place/textsearch/json';
   final String apiKEY;
+  final Map<String, String> headers;
 
-  Search(this.apiKEY);
+  Search(this.apiKEY, this.headers);
 
   /// A Find Place request takes a text input and returns a place.
   /// The input can be any kind of Places text data, such as a name, address, or phone number.
@@ -55,7 +57,7 @@ class Search {
     );
 
     var uri = Uri.https(_authority, _unencodedPathFindPlace, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return FindPlaceResponse.parseFindPlaceResult(response);
     }
@@ -131,7 +133,7 @@ class Search {
 
     var uri =
         Uri.https(_authority, _unencodedPathNearBySearch, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return NearBySearchResponse.parseNearBySearchResult(response);
     }
@@ -211,7 +213,7 @@ class Search {
     );
 
     var uri = Uri.https(_authority, _unencodedPathTextSearch, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return TextSearchResponse.parseTextSearchResult(response);
     }
@@ -234,7 +236,9 @@ class Search {
       'key': apiKEY,
       'inputtype': inputType == InputType.TextQuery
           ? 'textquery'
-          : inputType == InputType.PhoneNumber ? 'phonenumber' : 'textquery',
+          : inputType == InputType.PhoneNumber
+              ? 'phonenumber'
+              : 'textquery',
     };
 
     if (language != null && language != '') {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_place
 description: A new Flutter package for handle google place api that place search and details and photos and autocomplete and query autocomplete requests are available
-version: 0.4.0
+version: 0.3.4
 homepage: https://github.com/bazrafkan/google_place
 
 environment:


### PR DESCRIPTION
Required to use platform-specific API keys where you must provide the following headers:

```dart
    final headers = <String, String>{
      if (defaultTargetPlatform == TargetPlatform.iOS)
        'x-ios-bundle-identifier': Env().bundleIdentifier, // com.my.app
      if (defaultTargetPlatform == TargetPlatform.android) ...{
        'x-android-package': Env().bundleIdentifier, // com.my.app
        'x-android-cert': Env().ANDROID_SIGNING_KEY_SHA1, // signing key used to build/publish the app
      }
    };
```
