### PR TITLE
Improved proxyUri handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.4.4] - 2021-08-10
+
+- Added support for more proxy URI's, 
+- Added tests & manually tested with http://cors-anywhere.herokuapp.com
+- GooglePlace::proxyUrl can now be formatted as [https:// || http://]host[:<port>][/<path>][?<url-param-name>=]
+
 ## [0.4.3] - 2021-07-25
 
 - Add get json output

--- a/lib/google_place.dart
+++ b/lib/google_place.dart
@@ -68,6 +68,8 @@ class GooglePlace {
   final Map<String, String> headers;
 
   /// Optional proxy url to web request
+  /// Can be formatted as [https:// || http://]host[:<port>][/<path>][?<url-param-name>=]
+  /// http proxies are supported, but are not recommended for production use.
   final String? proxyUrl;
 
   GooglePlace(

--- a/lib/src/autocomplete/autocomplete.dart
+++ b/lib/src/autocomplete/autocomplete.dart
@@ -1,7 +1,4 @@
 import 'package:google_place/google_place.dart';
-import 'package:google_place/src/autocomplete/autocomplete_response.dart';
-import 'package:google_place/src/models/component.dart';
-import 'package:google_place/src/models/lat_lon.dart';
 import 'package:google_place/src/utils/network_utility.dart';
 
 class Autocomplete {

--- a/lib/src/autocomplete/autocomplete.dart
+++ b/lib/src/autocomplete/autocomplete.dart
@@ -102,13 +102,7 @@ class Autocomplete {
       strictbounds,
     );
 
-    var uri = Uri.https(
-      proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
-      queryParameters,
-    );
+    var uri = NetworkUtility.createUri(proxyUrl, _authority, _unencodedPath, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);
@@ -206,9 +200,7 @@ class Autocomplete {
 
     var uri = Uri.https(
       proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
+      proxyUrl != null && proxyUrl != '' ? 'https://$_authority/$_unencodedPath' : _unencodedPath,
       queryParameters,
     );
     return await NetworkUtility.fetchUrl(uri, headers: headers);

--- a/lib/src/details/details.dart
+++ b/lib/src/details/details.dart
@@ -52,14 +52,7 @@ class Details {
       sessionToken,
       fields,
     );
-
-    var uri = Uri.https(
-      proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
-      queryParameters,
-    );
+    var uri = NetworkUtility.createUri(proxyUrl, _authority, _unencodedPath, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return DetailsResponse.parseDetailsResult(response);
@@ -111,9 +104,7 @@ class Details {
 
     var uri = Uri.https(
       proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
+      proxyUrl != null && proxyUrl != '' ? 'https://$_authority/$_unencodedPath' : _unencodedPath,
       queryParameters,
     );
     return await NetworkUtility.fetchUrl(uri, headers: headers);

--- a/lib/src/photos/photos.dart
+++ b/lib/src/photos/photos.dart
@@ -40,13 +40,7 @@ class Photos {
       maxHeight,
       maxWidth,
     );
-    var uri = Uri.https(
-      proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
-      queryParameters,
-    );
+    var uri = NetworkUtility.createUri(proxyUrl, _authority, _unencodedPath, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       List<int> list = response.codeUnits;
@@ -86,9 +80,7 @@ class Photos {
     );
     var uri = Uri.https(
       proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
+      proxyUrl != null && proxyUrl != '' ? 'https://$_authority/$_unencodedPath' : _unencodedPath,
       queryParameters,
     );
     return await NetworkUtility.fetchUrl(uri, headers: headers);

--- a/lib/src/query_autocomplete/query_autocomplete.dart
+++ b/lib/src/query_autocomplete/query_autocomplete.dart
@@ -50,14 +50,7 @@ class QueryAutocomplete {
       radius,
       language,
     );
-
-    var uri = Uri.https(
-      proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
-      queryParameters,
-    );
+    var uri = NetworkUtility.createUri(proxyUrl, _authority, _unencodedPath, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);
@@ -104,13 +97,7 @@ class QueryAutocomplete {
       language,
     );
 
-    var uri = Uri.https(
-      proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPath'
-          : _unencodedPath,
-      queryParameters,
-    );
+    var uri = NetworkUtility.createUri(proxyUrl, _authority, _unencodedPath, queryParameters);
     return await NetworkUtility.fetchUrl(uri, headers: headers);
   }
 

--- a/lib/src/query_autocomplete/query_autocomplete.dart
+++ b/lib/src/query_autocomplete/query_autocomplete.dart
@@ -1,6 +1,4 @@
 import 'package:google_place/google_place.dart';
-import 'package:google_place/src/autocomplete/autocomplete_response.dart';
-import 'package:google_place/src/models/lat_lon.dart';
 import 'package:google_place/src/utils/network_utility.dart';
 
 class QueryAutocomplete {

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -10,8 +10,7 @@ import 'package:google_place/src/utils/network_utility.dart';
 
 class Search {
   static final _authority = 'maps.googleapis.com';
-  static final _unencodedPathFindPlace =
-      'maps/api/place/findplacefromtext/json';
+  static final _unencodedPathFindPlace = 'maps/api/place/findplacefromtext/json';
   static final _unencodedPathNearBySearch = 'maps/api/place/nearbysearch/json';
   static final _unencodedPathTextSearch = 'maps/api/place/textsearch/json';
   final String apiKEY;
@@ -57,13 +56,7 @@ class Search {
       locationbias,
     );
 
-    var uri = Uri.https(
-      proxyUrl != null && proxyUrl != '' ? proxyUrl! : _authority,
-      proxyUrl != null && proxyUrl != ''
-          ? 'https://$_authority/$_unencodedPathFindPlace'
-          : _unencodedPathFindPlace,
-      queryParameters,
-    );
+    var uri = NetworkUtility.createUri(proxyUrl, _authority, _unencodedPathFindPlace, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return FindPlaceResponse.parseFindPlaceResult(response);
@@ -138,8 +131,7 @@ class Search {
       pagetoken,
     );
 
-    var uri =
-        Uri.https(_authority, _unencodedPathNearBySearch, queryParameters);
+    var uri = Uri.https(_authority, _unencodedPathNearBySearch, queryParameters);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return NearBySearchResponse.parseNearBySearchResult(response);
@@ -341,8 +333,7 @@ class Search {
       pagetoken,
     );
 
-    var uri =
-        Uri.https(_authority, _unencodedPathNearBySearch, queryParameters);
+    var uri = Uri.https(_authority, _unencodedPathNearBySearch, queryParameters);
     return await NetworkUtility.fetchUrl(uri, headers: headers);
   }
 
@@ -463,8 +454,7 @@ class Search {
         value = 'ipbias';
       }
       if (locationbias.point != null) {
-        value =
-            'point:${locationbias.point!.latitude},${locationbias.point!.longitude}';
+        value = 'point:${locationbias.point!.latitude},${locationbias.point!.longitude}';
       }
       if (locationbias.circular != null) {
         value =

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -1,11 +1,4 @@
 import 'package:google_place/google_place.dart';
-import 'package:google_place/src/models/input_type.dart';
-import 'package:google_place/src/models/location.dart';
-import 'package:google_place/src/models/locationbias.dart';
-import 'package:google_place/src/models/rank-by.dart';
-import 'package:google_place/src/search/find_place_response.dart';
-import 'package:google_place/src/search/near_by_search_response.dart';
-import 'package:google_place/src/search/text_search_response.dart';
 import 'package:google_place/src/utils/network_utility.dart';
 
 class Search {

--- a/lib/src/utils/network_utility.dart
+++ b/lib/src/utils/network_utility.dart
@@ -8,8 +8,7 @@ class NetworkUtility {
     Map<String, String>? headers,
   }) async {
     try {
-      final response =
-          await http.get(uri, headers: headers).timeout(GooglePlace.timeout);
+      final response = await http.get(uri, headers: headers).timeout(GooglePlace.timeout);
       if (response.statusCode == 200) {
         return response.body;
       }
@@ -17,5 +16,78 @@ class NetworkUtility {
     } catch (e) {
       return null;
     }
+  }
+
+  /// Creates a uri with the proxy url if it is set
+  /// [proxyUrl] Required parameters - can be formatted as [https://]host[:<port>][/<path>][?<url-param-name>=] only https proxies are supported.
+  /// [authority] Required parameters - the domain name of the google server, usually https://maps.googleapis.com
+  /// [unencodedGoogleMapsPath] Required parameters - the path to the api, usually something like maps/api/...
+  /// [queryParameters] Required parameters - a map of query parameters to be appended to the url
+  static Uri createUri(String? proxyUrl, String authority, String unencodedGoogleMapsPath,
+      Map<String, String?> queryParameters) {
+    Uri uri;
+    final googleApiUri = Uri.https(
+      authority,
+      unencodedGoogleMapsPath,
+      queryParameters,
+    );
+
+    if (proxyUrl != null && proxyUrl != '') {
+      bool usingHttps = true;
+      String everythingAfterHostname = '';
+      String proxyHostname = proxyUrl;
+      if (proxyUrl.startsWith('https://')) {
+        proxyHostname = proxyUrl.replaceFirst("https://", "");
+        usingHttps = true;
+      } else if (proxyUrl.startsWith('http://')) {
+        proxyHostname = proxyUrl.replaceFirst("http://", "");
+        usingHttps = false;
+      }
+
+      if (proxyHostname.contains("/")) {
+        everythingAfterHostname = proxyHostname.substring(proxyHostname.indexOf("/"));
+        proxyHostname = proxyHostname.substring(0, proxyHostname.indexOf("/"));
+      }
+
+      if (everythingAfterHostname.contains("?") && everythingAfterHostname.contains("=")) {
+        var proxyPath = everythingAfterHostname.substring(0, everythingAfterHostname.indexOf("?"));
+        var parameterName = everythingAfterHostname.substring(
+            everythingAfterHostname.indexOf("?") + 1, everythingAfterHostname.indexOf("="));
+        var googleMapsUrlParam = {parameterName: googleApiUri.toString()};
+        queryParameters.addAll(googleMapsUrlParam);
+        if (usingHttps) {
+          uri = Uri.https(
+            proxyHostname,
+            proxyPath,
+            queryParameters,
+          );
+        } else {
+          uri = Uri.http(
+            proxyHostname,
+            proxyPath,
+            queryParameters,
+          );
+        }
+      } else {
+        //no parameter
+        if (usingHttps) {
+          uri = Uri.https(
+            proxyHostname,
+            '${everythingAfterHostname}https://$authority/$unencodedGoogleMapsPath',
+            queryParameters,
+          );
+        } else {
+          uri = Uri.http(
+            proxyHostname,
+            '${everythingAfterHostname}http://$authority/$unencodedGoogleMapsPath',
+            queryParameters,
+          );
+        }
+      }
+    } else {
+      uri = googleApiUri;
+    }
+    // print(uri.toString());
+    return uri;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_place
 description: A new Flutter package for handle google place api that place search and details and photos and autocomplete and query autocomplete requests are available
-version: 0.4.3
+version: 0.4.4
 homepage: https://github.com/bazrafkan/google_place
 
 environment:

--- a/test/google_place_test.dart
+++ b/test/google_place_test.dart
@@ -2,10 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:google_place/google_place.dart';
 
 void main() {
+  String apiKey = "Your-Key";
   test('init', () async {
-    String apiKey = "Your-Key";
-    var googlePlace =
-        GooglePlace(apiKey, proxyUrl: 'cors-anywhere.herokuapp.com');
+    var googlePlace = GooglePlace(apiKey, proxyUrl: 'cors-anywhere.herokuapp.com');
     expect(googlePlace.apiKEY, apiKey);
     expect(googlePlace.search.apiKEY, apiKey);
     expect(googlePlace.details.apiKEY, apiKey);
@@ -13,5 +12,22 @@ void main() {
     await googlePlace.photos.get("photoReference", 10, 10);
     expect(googlePlace.autocomplete.apiKEY, apiKey);
     expect(googlePlace.queryAutocomplete.apiKEY, apiKey);
+  });
+  test('proxies with paths and parameters', () async {
+    GooglePlace googlePlace;
+    //try some good proxy urls
+    googlePlace = GooglePlace(apiKey, proxyUrl: 'localhost:6969');
+    await googlePlace.autocomplete.get("some place");
+    googlePlace = GooglePlace(apiKey, proxyUrl: 'https://localhost:6969');
+    await googlePlace.photos.get("photoReference", 10, 10);
+    googlePlace = GooglePlace(apiKey, proxyUrl: 'https://1.2.3.4/proxy');
+    await googlePlace.queryAutocomplete.get("some place");
+    googlePlace = GooglePlace(apiKey, proxyUrl: 'https://localhost:6969/proxy/proxy-two/');
+    await googlePlace.search.getFindPlace("some place", InputType.TextQuery);
+    googlePlace = GooglePlace(apiKey, proxyUrl: 'localhost:6969/proxy/proxy-two?gmapsurl=');
+    await googlePlace.autocomplete.get("some place");
+    //try a bad hostname
+    googlePlace = GooglePlace(apiKey, proxyUrl: 'localhost:6969******');
+    expect(googlePlace.autocomplete.get("some place"), throwsException);
   });
 }


### PR DESCRIPTION
`GooglePlace::proxyUrl can now be formatted as [https:// || http://]host[:<port>][/<path>][?<url-param-name>=]`