### PR TITLE
Exposes timeout duration

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -102,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/lib/google_place.dart
+++ b/lib/google_place.dart
@@ -72,11 +72,9 @@ class GooglePlace {
   /// http proxies are supported, but are not recommended for production use.
   final String? proxyUrl;
 
-  GooglePlace(
-    this.apiKEY, {
-    this.headers = const {},
-    this.proxyUrl,
-  }) {
+  GooglePlace(this.apiKEY,
+      {this.headers = const {}, this.proxyUrl, Duration? duration}) {
+    if (duration != null) timeout = duration;
     this.search = Search(apiKEY, headers, proxyUrl);
     this.details = Details(apiKEY, headers, proxyUrl);
     this.photos = Photos(apiKEY, headers, proxyUrl);

--- a/lib/google_place.dart
+++ b/lib/google_place.dart
@@ -71,10 +71,10 @@ class GooglePlace {
   /// Can be formatted as [https:// || http://]host[:<port>][/<path>][?<url-param-name>=]
   /// http proxies are supported, but are not recommended for production use.
   final String? proxyUrl;
-
+  set setTimeout(Duration duration) => timeout = duration;
   GooglePlace(this.apiKEY,
-      {this.headers = const {}, this.proxyUrl, Duration? duration}) {
-    if (duration != null) timeout = duration;
+      {this.headers = const {}, this.proxyUrl, Duration? timeoutDuration}) {
+    if (timeoutDuration != null) timeout = timeoutDuration;
     this.search = Search(apiKEY, headers, proxyUrl);
     this.details = Details(apiKEY, headers, proxyUrl);
     this.photos = Photos(apiKEY, headers, proxyUrl);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,14 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -148,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -162,6 +169,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.7"
+    version: "1.2.1"
   http_parser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "1.2.7"
   http_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  http: ^1.2.7
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  http: ^0.13.3
+  http: ^1.2.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
fixes #38
Although given the option to increase the timeout duration, I found out that it is faster to let the request timeout and send it again. So I recommend leaving the timeout to 1.5 seconds and resend your request if it timesout. 